### PR TITLE
Import some things directly from distribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,20 +4,12 @@
 import os
 import subprocess
 
-try:
-    from setuptools import setup
-    from setuptools.file_util import copy_file
-    from setuptools.command.install import install
-    from setuptools.command.build import build
-    from setuptools.command.clean import clean
-    from setuptools.spawn import find_executable
-except ImportError:
-    from distutils.core import setup
-    from distutils.file_util import copy_file
-    from distutils.command.install import install
-    from distutils.command.build import build
-    from distutils.command.clean import clean
-    from distutils.spawn import find_executable
+from setuptools import setup
+from setuptools.command.install import install
+from distutils.file_util import copy_file
+from distutils.command.build import build
+from distutils.command.clean import clean
+from distutils.spawn import find_executable
 
 with open('README.rst') as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
@dzwarg I was only able to successfully pip install by passing the `--egg` flag. Without `--egg` I get the traceback (below). I dug around and people said upgrading setuptools or using setuptools instead of distribute would do the trick. In the code the setuptools import for copy_file was failing, and `setup` and `install` and the other setuptools imports were being either shadowed by or skipped by the imports from distribute. I kept the imports work from setuptools and left the others explicitly to distribute and now `pip install .` works along with `python setup.py install`, etc. 

```
(py4jdbctest):[twneale@mm] /tmp/py4jdbc (improve-setup *)$ pip install . --upgrade
Unpacking /tmp/py4jdbc
  Running setup.py (path:/tmp/pip-854hssq6-build/setup.py) egg_info for package from file:///tmp/py4jdbc

Requirement already up-to-date: py4j==0.10.1 in /home/twneale/.virtualenvs/py4jdbctest/lib/python3.5/site-packages (from py4jdbc==0.1.6.3)
Installing collected packages: py4jdbc
  Found existing installation: py4jdbc 0.1.6.3
    Not uninstalling py4jdbc at /tmp/py4jdbc, outside environment /home/twneale/.virtualenvs/py4jdbctest
  Running setup.py install for py4jdbc
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       or: -c --help [cmd1 cmd2 ...]
       or: -c --help-commands
       or: -c cmd --help

    error: option --single-version-externally-managed not recognized
    Complete output from command /home/twneale/.virtualenvs/py4jdbctest/bin/python3.5 -c "import setuptools, tokenize;__file__='/tmp/pip-854hssq6-build/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-gt0p2v78-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/twneale/.virtualenvs/py4jdbctest/include/site/python3.5:
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]

   or: -c --help [cmd1 cmd2 ...]

   or: -c --help-commands

   or: -c cmd --help
