### PR TITLE
Improve Setup for this lib as a dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,6 @@ COPY py4jdbc/scala ./py4jdbc/scala
 RUN cd /py4jdbc/py4jdbc/scala && sbt clean
 
 COPY . ./
-RUN python setup.py build --with-jar=True install --with-jar=/usr/local/lib
-ENV CLASSPATH=/usr/local/lib/py4jdbc-assembly-0.1.6.5.jar
+RUN python setup.py build sdist
+RUN cd /py4jdbc/dist && pip install py4jdbc-0.1.6.5.tar.gz
+ENV CLASSPATH=/usr/local/share/py4jdbc/py4jdbc-assembly-0.1.6.5.jar

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include py4jdbc/scala/target/scala-2.10/py4jdbc-assembly-0.1.6.5.jar

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,21 @@
 Py4jdbc
 ===========
 
-Py4jdbc is a (mostly) `dbapi 2.0 <https://www.python.org/dev/peps/pep-0249/>`_ compliant interface to JDBC. It's similar to `JayDeBeAPI <https://github.com/baztian/jaydebeapi>`_, but uses a much more efficient JVM backend process implemented with Py4j instead of JPype.
+Py4jdbc is a (mostly) `dbapi 2.0 <https://www.python.org/dev/peps/pep-0249/>`_ compliant interface to JDBC.
+It's similar to `JayDeBeAPI <https://github.com/baztian/jaydebeapi>`_, but uses a much more efficient JVM
+backend process implemented with Py4j instead of JPype.
 
-Install py4jdbc
+Install with pip
 ++++++++++++++++
 
-You can also pip install py4jdbc, but you'll have to manually dig up the jar file and add it to your $CLASSPATH.
+    pip install py4jdbc
+
+Install from source tarball
++++++++++++++++++++++++++++
+
+    tar -zxf py4jdbc-V.X.Y.Z.tar.gz
+    cd py4jdbc-V.X.Y.Z
+    python setup.py install
 
 Example
 ++++++++++++

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 pytest
 coverage
 pytest-cov
+tox

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-python setup.py clean sdist upload
+python setup.py clean build sdist

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-python setup.py clean sdist bdist bdist_egg bdist_wheel upload
+python setup.py clean sdist upload

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-python setup.py clean build sdist
+python setup.py clean build sdist upload

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@ import os
 import subprocess
 
 from setuptools import setup
-from setuptools.command.install import install
-from distutils.file_util import copy_file
 from distutils.command.build import build
 from distutils.command.clean import clean
 from distutils.spawn import find_executable
@@ -21,69 +19,13 @@ test_requirements = ["pytest==2.9.2", "coverage==4.1", "pytest-cov==2.3.0"]
 exec(compile(open("py4jdbc/version.py").read(), "py4jdbc/version.py", 'exec'))
 VERSION = __version__  # noqa
 
-class JarUtility(object):
-
-    def _initialize_options(self, parent):
-        parent.initialize_options(self)
-        self.with_jar = False
-        self.jar_dest = None
-
-    def _finalize_options(self, parent, accept_path=False):
-        parent.finalize_options(self)
-
-        if self.with_jar == 'system':
-            # Install the jar in the system classpath
-            self.jar_dest = self.get_system_cp()
-            self.with_jar = True
-        elif self.with_jar:
-            if accept_path:
-                # Install the jar in a custom directory
-                self.jar_dest = os.path.realpath(self.with_jar)
-                self.with_jar = os.path.exists(self.jar_dest)
-
-                if not self.with_jar:
-                    # Directory must exist
-                    self.jar_dest = None
-            else:
-                if self.with_jar.lower() not in ['true', 't', 'yes', 'y', '1']:
-                    msg = 'Invalid argument for --with-jar: %r'
-                    raise ValueError(msg % self.with_jar)
-                self.with_jar = True
-
-
-    def get_system_cp(self):
-        """
-        Get the system classpath, based on the default 'java' executable found in the path.
-        """
-        return os.path.normpath(os.path.join(os.path.realpath(find_executable('java')), '../../lib/ext'))
-
-    def clean_cp(self):
-        """
-        Clean the classpath of the built jar -- it won't build or clean if the jar is already
-        in the classpath.
-        """
-        dest = self.get_system_cp()
-
-        if os.path.exists("{0}/py4jdbc-assembly-{1}.jar".format(dest, __version__)):
-            os.remove("{0}/py4jdbc-assembly-{1}.jar".format(dest, __version__))
-
-class jar_build(build, JarUtility):
-    user_options = build.user_options + [
-        ('with-jar=', None, 'Build Java sources with \'sbt\' in addition to Python sources.',)
-    ]
-
-    def initialize_options(self):
-        self._initialize_options(build)
-
-    def finalize_options(self):
-        self._finalize_options(build, accept_path=False)
-
+class jar_build(build):
     def run(self):
         """
         Compile the companion jar file.
         """
 
-        if self.with_jar and find_executable('sbt') is None:
+        if find_executable('sbt') is None:
             raise EnvironmentError("""
 
 The executable "sbt" cannot be found.
@@ -93,66 +35,22 @@ Please install the "sbt" tool to build the companion jar file.
 
         build.run(self)
 
-        if self.with_jar:
-            if self.jar_dest == self.get_system_cp():
-                # Remove any previous jar from the classpath if
-                # installing into the system classpath
-                self.clean_cp()
+        cwd = os.getcwd()
+        os.chdir('py4jdbc/scala')
+        subprocess.check_call('sbt assembly', shell=True)
+        os.chdir(cwd)
 
-            cwd = os.getcwd()
-            os.chdir('py4jdbc/scala')
-            subprocess.check_call('sbt assembly', shell=True)
-            os.chdir(cwd)
-
-class jar_install(install, JarUtility):
-    user_options = install.user_options + [
-        ('with-jar=', None, 'Install companion jar file.')
-    ]
-
-    def initialize_options(self):
-        self._initialize_options(install)
-
-    def finalize_options(self):
-        self._finalize_options(install, accept_path=True)
-
+class jar_clean(clean):
     def run(self):
         """
-        Install the companion jar file.
+        Cleans the scala targets from the system.
         """
-        install.run(self)
-
-        if self.with_jar:
-            copy_file("py4jdbc/scala/target/scala-2.10/py4jdbc-assembly-{0}.jar".format(__version__),
-                      "{0}/py4jdbc-assembly-{1}.jar".format(self.jar_dest, __version__))
-
-class jar_clean(clean, JarUtility):
-    user_options = clean.user_options + [
-        ('with-jar=', None, 'Clean companion jar file.')
-    ]
-
-    def initialize_options(self):
-        self._initialize_options(clean)
-
-    def finalize_options(self):
-        self._finalize_options(clean)
-
-    def run(self):
-        """
-        Cleans the .jar file from the system.
-        """
-        if self.with_jar:
-            if self.jar_dest == self.get_system_cp():
-                # Remove any previous jar from the classpath if
-                # installing into the system classpath
-                self.clean_cp()
-
         clean.run(self)
 
-        if self.with_jar:
-            cwd = os.getcwd()
-            os.chdir('py4jdbc/scala')
-            subprocess.check_call('sbt clean', shell=True)
-            os.chdir(cwd)
+        cwd = os.getcwd()
+        os.chdir('py4jdbc/scala')
+        subprocess.check_call('sbt clean', shell=True)
+        os.chdir(cwd)
 
 setup(
     name='py4jdbc',
@@ -180,7 +78,6 @@ setup(
     tests_require=test_requirements,
     cmdclass={
         'build': jar_build,
-        'install': jar_install,
         'clean': jar_clean
     },
     package_data={
@@ -191,5 +88,8 @@ setup(
             'scala/src/main/scala/GatewayServer.scala'
         ]
     },
+    data_files=[
+        ('share/py4jdbc', ["py4jdbc/scala/target/scala-2.10/py4jdbc-assembly-{0}.jar".format(__version__)])
+    ],
     setup_requires=setup_requirements
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,6 @@ deps = pytest
 setenv =
     CLASSPATH = {toxinidir}/scala/target/scala-2.10/py4jdbc-assembly-0.1.6.5.jar
 commands =
-    py4jdbc-tox-sbtassembly
-    py.test -vv tests/
+    python setup.py build --with-jar=True install
+    python setup.py test --addopts '-vv'
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,6 @@ deps = pytest
 setenv =
     CLASSPATH = {toxinidir}/scala/target/scala-2.10/py4jdbc-assembly-0.1.6.5.jar
 commands =
-    python setup.py build --with-jar=True install
+    python setup.py build install
     python setup.py test --addopts '-vv'
 


### PR DESCRIPTION
Egg, wheel, and any bdist package won't install the companion JAR file.
The only method that seems to work is distributing a source-only
tarball, and running pip install on that tarball. Otherwise, some build
steps are skipped, or data files aren't installed, etc.

Additionally, the installation now follows the pattern from py4j for the
location of the jar file, installing it in the system "share" directory.